### PR TITLE
Fix: skip injection when concept is None; injector no-op for empty concepts

### DIFF
--- a/experiments/concept_decay.py
+++ b/experiments/concept_decay.py
@@ -79,7 +79,10 @@ def run_concept_decay_experiment(
     - results: dict – containing arc length, half-life, drift curve, and prompt metadata
     """
     # Step 1: Construct probe-injected prompt
-    full_prompt = inject_probe(base_prompt, concept, position=inject_pos)
+    if concept is None:
+        full_prompt = base_prompt
+    else:
+        full_prompt = inject_probe(base_prompt, concept, position=inject_pos)
     
     # Step 2: Run model and capture hidden state trajectory
     # Use the specific layer extraction function and pass layer_idx

--- a/interpretability/injector.py
+++ b/interpretability/injector.py
@@ -14,6 +14,8 @@ def inject_probe(base_prompt: str, concept: str, position: str = "middle") -> st
     Returns:
         str: The modified prompt with the concept inserted.
     """
+    if concept is None or str(concept).strip() == "":
+        return base_prompt
     tokens = base_prompt.strip().split()
 
     if position == "start":


### PR DESCRIPTION
## Summary
Fix baseline behavior where concept=None resulted in the literal string None being injected into the prompt. Now baseline runs do not modify the prompt, and the injector safely no-ops for None or empty concepts.

## What changed
- experiments/concept_decay.py: Guard Step 1 to bypass inject_probe when concept is None.
- interpretability/injector.py: Early return of base_prompt when concept is None or whitespace only.

## Rationale
The README promises a baseline mode that runs without injecting a concept. Previously, passing no --concept still injected the string None due to unconditional use of inject_probe. This change makes behavior match documentation and avoids unintended prompt mutations.

## How to test
1) Baseline run without concept:
   python run_experiment.py --prompt "The cat sat on the mat." --no_visual --no_save
   Expected: injected_prompt equals the base prompt. No injected token appears.

2) Explicit concept:
   python run_experiment.py --prompt "The cat sat on the mat." --concept happiness --inject_pos middle --no_visual --no_save
   Expected: injected prompt contains happiness in the middle.

3) Injector edge cases:
   From a Python REPL:
   >>> from interpretability.injector import inject_probe
   >>> inject_probe("hello world", None, "start")
   "hello world"
   >>> inject_probe("hello world", "  ", "end")
   "hello world"

## Notes
- This is a minimal and backward compatible fix.
- Follow ups could adjust plot titles during baseline runs to avoid printing None in the title, and align axis labels with the actual metric used.

## Checklist
- [x] Code builds
- [x] Manual sanity tests for baseline and concept injection
- [x] No behavior change for valid non empty concepts
